### PR TITLE
feat: Inject content script and render switcher on demand

### DIFF
--- a/background.js
+++ b/background.js
@@ -208,19 +208,6 @@ function injectTabSwitcher(tabId, url) {
   );
 }
 
-// Install/update: inject content script into all existing eligible tabs.
-chrome.runtime.onInstalled.addListener((details) => {
-  if (details.reason === 'install' || details.reason === 'update') {
-    chrome.tabs.query({}, (tabs) => {
-      tabs.forEach((tab) => {
-        if (typeof tab.id === 'number') {
-          injectTabSwitcher(tab.id, tab.url);
-        }
-      });
-    });
-  }
-});
-
 // Handle keyboard shortcut defined in manifest to toggle the tab switcher overlay.
 chrome.commands.onCommand.addListener((command) => {
   if (command !== 'toggle_tab_switcher') return;

--- a/tabSwitcherContent.js
+++ b/tabSwitcherContent.js
@@ -276,9 +276,8 @@
         // Render the tab list
         renderTabs(tabData);
       } else {
-        // If the switcher was already open, move selection to the next tab
-        selectedIndex = (selectedIndex + 1) % currentTabData.length;
-        updateSelection();
+        // If the switcher was already open, destroy it
+        destroyOverlay();
       }
     }
   });


### PR DESCRIPTION
This commit modifies the extension to inject the content script and render the switcher component only when the keyboard shortcut is triggered.

The `onInstalled` listener in `background.js` has been removed to prevent the content script from being injected into all tabs on installation.

The `onMessage` listener in `tabSwitcherContent.js` has been updated to destroy the overlay if it's already visible when the `show_tab_switcher` message is received. This allows the keyboard shortcut to also act as a toggle to close the switcher.